### PR TITLE
fix(failsafe): improve reloading

### DIFF
--- a/internal/controller/failsafe.go
+++ b/internal/controller/failsafe.go
@@ -43,8 +43,8 @@ func (c *Controller) FailsafeConfiguration(g *gin.Context) {
 				err = encoder.Encode(newConfig)
 
 				if err == nil {
+					g.JSON(http.StatusOK, gin.H{})
 					c.Restart()
-					g.Redirect(http.StatusFound, "/")
 					return
 				}
 			}
@@ -84,8 +84,8 @@ func (c *Controller) FailsafeUser(g *gin.Context) {
 
 				err = c.datastore.Create(&admin).Error
 				if err == nil {
+					g.JSON(http.StatusOK, gin.H{})
 					c.Restart()
-					g.Redirect(http.StatusFound, "/")
 					return
 				}
 			}

--- a/internal/http/type.go
+++ b/internal/http/type.go
@@ -53,6 +53,11 @@ func NewFailsafeConfig(c controller.AbtractController, embedfs *embed.FS) (*Serv
 	server.Router.GET("", c.FailsafeConfiguration)
 	server.Router.POST("", c.FailsafeConfiguration)
 
+	// add rerouting for other requests
+	server.Router.NoRoute(func(c *gin.Context) {
+		c.Redirect(http.StatusFound, "/")
+	})
+
 	return server, nil
 }
 
@@ -102,6 +107,11 @@ func NewFailsafeUser(c controller.AbtractController, embedfs *embed.FS) (*Server
 	// failsafe configuration route
 	server.Router.GET("", c.FailsafeUser)
 	server.Router.POST("", c.FailsafeUser)
+
+	// add rerouting for other requests
+	server.Router.NoRoute(func(c *gin.Context) {
+		c.Redirect(http.StatusFound, "/")
+	})
 
 	return server, nil
 }

--- a/web/page/common/base-failsafe.html
+++ b/web/page/common/base-failsafe.html
@@ -88,6 +88,7 @@
     <!-- Load JS -->
     <script src="/static/js/jquery-3.3.1.min.js"></script>
     <script src="/static/js/bootstrap-5.3.3.min.js"></script>
+    <script src="/static/js/vanilla-lazyload-19.1.3.min.js"></script>
     <script src="/static/js/main.js"></script>
 </body>
 

--- a/web/page/failsafe/config.html
+++ b/web/page/failsafe/config.html
@@ -70,14 +70,26 @@
 // this function check if the healthcheck endpoint is up
 // then redirect to the reloaded app
 function checkForReload() {
-  $.ajax({
+  console.debug('checking the /ping endpoint to determine when to reload');
+  ajaxSettings = {
     url: '/ping',
     type: 'GET',
-    success: function() {
+    retry: 10,
+    success: function(data) {
+      console.debug(data);
       console.log('reloading');
       window.location.reload();
-    }
-  });
+    },
+  };
+
+  $.ajax(ajaxSettings).fail(onFail);
+
+  function onFail(){
+    if (ajaxSettings.retry-- > 0)
+      setTimeout(function(){
+        $.ajax(ajaxSettings).fail(onFail);
+      }, 1000);
+  }
 }
 
 window.onload = function() {

--- a/web/page/failsafe/user.html
+++ b/web/page/failsafe/user.html
@@ -42,14 +42,26 @@
 // this function check if the healthcheck endpoint is up
 // then redirect to the reloaded app
 function checkForReload() {
-  $.ajax({
+  console.debug('checking the /ping endpoint to determine when to reload');
+  ajaxSettings = {
     url: '/ping',
     type: 'GET',
-    success: function() {
+    retry: 10,
+    success: function(data) {
+      console.debug(data);
       console.log('reloading');
       window.location.reload();
-    }
-  });
+    },
+  };
+
+  $.ajax(ajaxSettings).fail(onFail);
+
+  function onFail(){
+    if (ajaxSettings.retry-- > 0)
+      setTimeout(function(){
+        $.ajax(ajaxSettings).fail(onFail);
+      }, 1000);
+  }
 }
 
 window.onload = function() {


### PR DESCRIPTION
Reading content from the /ping endpoint ensures the browser actually wait before reloading the page. Returning the response as JSON ensure AJAX calls are running properly. Returing the response before reloading ensure the browser got the response entirely. Including a retry mechanism with a 1 second delay before attempts improve the success rate to catch the server once booted properly.