### PR TITLE
fix(adm/categories): remove max-height

### DIFF
--- a/web/page/adm/category.html
+++ b/web/page/adm/category.html
@@ -12,7 +12,6 @@
 }
 
 #categories-container .category-values {
-	max-height: 200px;
 	overflow-y: hidden;
 	grid-auto-columns: calc(16.66667% - var(--separator-width)*5/6);
 	grid-auto-flow: row;


### PR DESCRIPTION
The max-heigth property cause view truncation. Removing it does not impact the rest of the view.

Fix #108