### PR TITLE
fix(actor/edit): picture correct size (fix #107)

### DIFF
--- a/web/page/actor/edit.html
+++ b/web/page/actor/edit.html
@@ -197,8 +197,9 @@ const url_actor_category_edit = '/api/actor/{{ .Actor.ID }}/category/00000000-00
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body" id="profilePictureModalBody">
+        <h5 id="cropper-status"></h5>
         <div id="image_drop_area">
-          <img id="image" src=""></img>
+          <img id="image" src="" style="height: 100%; width: auto; display: none;"></img>
         </div>
       </div>
       <div class="modal-footer">

--- a/web/page/actor/edit.js
+++ b/web/page/actor/edit.js
@@ -267,6 +267,17 @@ window.onload = function() {
   document.modalNewAlias = document.getElementById("addActorAliasModal");
   document.modalNewAliasModal = new bootstrap.Modal(document.modalNewAlias);
 
+  const previewModal = document.getElementById('profilePictureModal');
+  previewModal.addEventListener('shown.bs.modal', previewModalShown);
+  previewModal.addEventListener('hide.bs.modal', event => {
+    cropper.destroy();
+  });
+
+  // register image onload
+  document.getElementById('image').onload = function() {
+    gen_new_crop();
+  }
+
   // register calls on modals
   $("#addActorAliasInput").on('keyup', function (e) {
       if (e.key === 'Enter' || e.keyCode === 13) {
@@ -332,35 +343,35 @@ function suggestProfilePicture() {
 }
 
 // set profile picture modal logic
-const previewModal = document.getElementById('profilePictureModal')
-previewModal.addEventListener('show.bs.modal', event => {
-  const caller = event.relatedTarget;
-  console.log(caller);
-  const profilePicturePreview = document.getElementById('image');
-  profilePicturePreview.src = caller.src;
-  setTimeout(gen_new_crop, "1000");
-})
-
-previewModal.addEventListener('hide.bs.modal', event => {
-  cropper.destroy();
-})
+function previewModalShown(event) {
+  // update status
+  document.getElementById('cropper-status').innerText = 'Cropper library loading...';
+  // set image src to caller one
+  document.getElementById('image').src = event.relatedTarget.src;
+}
 
 var cropper;
 function gen_new_crop() {
-  console.debug('halo');
   var image = document.querySelector('#image');
   var minAspectRatio = 1;
   var maxAspectRatio = 1;
   cropper = new Cropper(image, {
+    viewMode: 2,
+    initialAspectRatio: 1,
     ready: function () {
       var cropper = this.cropper;
       var containerData = cropper.getContainerData();
       var cropBoxData = cropper.getCropBoxData();
-      var aspectRatio = cropBoxData.width / cropBoxData.height;
-      var newCropBoxWidth;
+      var size = Math.min(image.width, image.height);
 
-      cropper.setCropBoxData(cropper.getImageData());
+      cropper.setCropBoxData({
+        top: 0,
+        left: 0,
+        width: size,
+        height: size,
+      });
       cropper.moveTo(0);
+      document.getElementById('cropper-status').innerText = 'Cropper library ready';
     },
 
     cropmove: function () {


### PR DESCRIPTION
Previously, if the profile picture was larger than the canvas, it would overflow during the library loading. This issue was caused because the picture was shown before the library at replaced it. Switching to `height: 100%; display: none` fixed this.

If the picture was smaller than the canvas, it would occasionally be scaled down to 100px. This issue happened because if the image was small enough, the library would load before the modal had finished loading, giving a parent size of 0. Updating the event from `show.bs.modal` to `shown.bs.modal` fixed this.